### PR TITLE
Force faucet battery to return None when not able to determine value.

### DIFF
--- a/raincloudy/faucet.py
+++ b/raincloudy/faucet.py
@@ -106,7 +106,8 @@ class RainCloudyFaucetCore(object):
     @property
     def battery(self):
         """Return faucet battery."""
-        return self._lookup_attr('active_faucet_battery_level')
+        battery_level = self._lookup_attr('active_faucet_battery_level')
+        return battery_level if isinstance(battery_level, int) else None
 
     def update(self):
         """Callback self._controller.update()."""


### PR DESCRIPTION
**Fixes**: #14 