### PR TITLE
Fix watering time to take both manual and auto minutes into account.  Fixes #33

### DIFF
--- a/raincloudy/faucet.py
+++ b/raincloudy/faucet.py
@@ -219,12 +219,24 @@ class RainCloudyFaucetZone(RainCloudyFaucetCore):
         ddata[attr] = value
         self.submit_action(ddata)
 
+    # TODO in a future release we should break this out. artifact of old API
     @property
     def watering_time(self):
         """Return watering_time from zone."""
         # zone starts with index 0
         index = self.id - 1
-        return self._attributes['rain_delay_mode'][index]['auto_watering_time']
+        auto_watering_time =\
+            self._attributes['rain_delay_mode'][index]['auto_watering_time']
+
+        manual_watering_time =\
+            self._attributes['rain_delay_mode'][index]['manual_watering_time']
+
+        if auto_watering_time > manual_watering_time:
+            watering_time = auto_watering_time
+        else:
+            watering_time = manual_watering_time
+
+        return watering_time
 
     @watering_time.setter
     def watering_time(self, value):

--- a/tests/fixtures/get_cu_and_fu_status.json
+++ b/tests/fixtures/get_cu_and_fu_status.json
@@ -18,22 +18,22 @@
     },
     {
       "next_water_cycle": "Off",
-      "manual_mode_on": false,
-      "manual_watering_time": 0,
-      "auto_watering_time": 0,
-      "program_mode_on": false,
+      "manual_mode_on": true,
+      "manual_watering_time": 15,
+      "auto_watering_time": 5,
+      "program_mode_on": true,
       "rain_delay_mode": 0,
-      "is_watering": false,
+      "is_watering": true,
       "zonename": 1
     },
     {
       "next_water_cycle": "Off",
-      "manual_mode_on": false,
-      "manual_watering_time": 0,
-      "auto_watering_time": 0,
-      "program_mode_on": false,
+      "manual_mode_on": true,
+      "manual_watering_time": 5,
+      "auto_watering_time": 60,
+      "program_mode_on": true,
       "rain_delay_mode": 0,
-      "is_watering": false,
+      "is_watering": true,
       "zonename": 2
     },
     {

--- a/tests/test_faucet_zone.py
+++ b/tests/test_faucet_zone.py
@@ -76,6 +76,17 @@ class TestRainCloudyFaucetZone(UnitTestBase):
                           faucet.zone1.id,
                           1000)
 
+    def test_watering_time(self):
+        """Test faucet.watering_time property"""
+        faucet = self.rdy.controller.faucet
+
+        # manual time
+        self.assertEqual(faucet.zone2.watering_time, 15)
+
+        # auto time
+        self.assertEqual(faucet.zone3.watering_time, 60)
+
+
     def test_errors_or_exceptions(self):
         """Tests for errors or exceptions."""
         faucet = self.rdy.controller.faucet


### PR DESCRIPTION
The new API has a field for both manual watering time and auto watering time. When I initially rebuilt the core attribute handler in the module I only grabbed the `auto_watering_time` field and returned it from `watering_time`. This meant that when Home Assistant tried to compute watering minutes after turning on a manual switch it was always 0. This PR addresses this by considering _both_ attributes and returning the largest of the 2. 

Would be nice to cut a `0.0.7` release for this so I can bump HA again before the beta window closes.