### PR TITLE
fix(deps): add aiohttp to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url="https://github.com/tchellomello/raincloudy",
     license="Apache License 2.0",
     include_package_data=True,
-    install_requires=["requests>=2.0", "beautifulsoup4", "urllib3>=1.22", "html5lib==1.1"],
+    install_requires=["aiohttp", "requests>=2.0", "beautifulsoup4", "urllib3>=1.22", "html5lib==1.1"],
     test_suite="tests",
     keywords=[
         "garden",


### PR DESCRIPTION
Otherwise, after running `pip install .`:

	>>> import raincloudy
	Traceback (most recent call last):
	  File "<stdin>", line 1, in <module>
	  File "/raincloudy/raincloudy/__init__.py", line 6, in <module>
	    from .aio.core import RainCloudy as RainCloudyAsync  # noqa: F401
	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "/raincloudy/raincloudy/aio/core.py", line 10, in <module>
	    from aiohttp.client import ClientSession
	ModuleNotFoundError: No module named 'aiohttp'