### PR TITLE
fix: don't set packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ def readme():
 
 setup(
     name="raincloudy",
-    packages=["raincloudy"],
     version="0.0.0",
     description="A Python library to communicate with Melnor \
                  RainCloud Smart Garden Watering Irrigation Timer \


### PR DESCRIPTION
Addresses the following warning:

> /usr/local/lib/python3.11/site-packages/setuptools/command/build_py.py:202: SetuptoolsDeprecationWarning:     Installing 'raincloudy.aio' as data is deprecated, please list it in `packages`.
>     !!
>
>
>     ############################
>     # Package would be ignored #
>     ############################
>     Python recognizes 'raincloudy.aio' as an importable package,
>     but it is not listed in the `packages` configuration of setuptools.
>
>     'raincloudy.aio' has been automatically added to the distribution only
>     because it may contain data files, but this behavior is likely to change
>     in future versions of setuptools (and therefore is considered deprecated).
>
>     Please make sure that 'raincloudy.aio' is included as a package by using
>     the `packages` configuration field or the proper discovery methods
>     (for example by using `find_namespace_packages(...)`/`find_namespace:`
>     instead of `find_packages(...)`/`find:`).
>
>     You can read more about "package discovery" and "data files" on setuptools
>     documentation page.
>
>
> !!

The fix would be to add raincloudy.aio to the packages field, but according to the [setuptools documentation][1], that field can now be omitted entirely in most cases, and setuptools will infer what to do. This seems to work for raincloudy.

[1]: https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#automatic-discovery